### PR TITLE
Add page transitions with fade, slide, and scale effects

### DIFF
--- a/assets/css/transitions.css
+++ b/assets/css/transitions.css
@@ -1,0 +1,34 @@
+/* Default page transition - fade */
+.page-enter-active,
+.page-leave-active {
+  transition: opacity 0.3s;
+}
+.page-enter-from,
+.page-leave-to {
+  opacity: 0;
+}
+
+/* Slide transition for content pages */
+.slide-left-enter-active,
+.slide-left-leave-active {
+  transition: all 0.3s ease-out;
+}
+.slide-left-enter-from {
+  opacity: 0;
+  transform: translateX(20px);
+}
+.slide-left-leave-to {
+  opacity: 0;
+  transform: translateX(-20px);
+}
+
+/* Scale transition for engagement pages */
+.scale-enter-active,
+.scale-leave-active {
+  transition: all 0.3s ease;
+}
+.scale-enter-from,
+.scale-leave-to {
+  opacity: 0;
+  transform: scale(0.98);
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,7 +8,15 @@ export default defineNuxtConfig({
     // Removed i18n module as it's not working and we're using static text instead
   ],
 
+  css: [
+    '@/assets/css/transitions.css'
+  ],
+
   app: {
+    pageTransition: {
+      name: 'page',
+      mode: 'out-in'
+    },
     head: {
       title: 'Stand Against Deportation',
       meta: [

--- a/pages/actions.vue
+++ b/pages/actions.vue
@@ -1,4 +1,11 @@
 <script setup>
+definePageMeta({
+  pageTransition: {
+    name: 'scale',
+    mode: 'out-in'
+  }
+});
+
 const { data: petitions } = await useFetch('/api/petitions');
 const { data: legislators } = await useFetch('/api/legislators');
 </script>

--- a/pages/community.vue
+++ b/pages/community.vue
@@ -1,4 +1,11 @@
 <script setup>
+definePageMeta({
+  pageTransition: {
+    name: 'scale',
+    mode: 'out-in'
+  }
+});
+
 const { data: forumThreads } = await useFetch('/api/forum');
 
 const formatDate = (timestamp) => {

--- a/pages/news.vue
+++ b/pages/news.vue
@@ -1,4 +1,11 @@
 <script setup>
+definePageMeta({
+  pageTransition: {
+    name: 'slide-left',
+    mode: 'out-in'
+  }
+});
+
 const { data: newsItems } = await useFetch('/api/news');
 const activeFilter = ref('#DueProcess');
 


### PR DESCRIPTION
This PR implements page transitions to enhance the user experience:

- Created transitions.css with fade, slide, and scale transitions
- Set default fade transition for all pages in nuxt.config.ts
- Applied slide transition to news page for content flow
- Applied scale transition to actions and community pages for engagement

All transitions are subtle, fast (0.3s), and mobile-friendly.